### PR TITLE
Fix test model path and restore dropout state

### DIFF
--- a/backend/app/core/predict.py
+++ b/backend/app/core/predict.py
@@ -113,6 +113,9 @@ class TrialPredictor:
                 out = self.model(sponsor_tensor, disease_tensor, incl_tensor, excl_tensor, summary_tensor, phase_tensor)
                 preds.append(torch.sigmoid(out).item())
 
+        # Reset model to evaluation mode after sampling
+        self.model.eval()
+
         preds_np = np.array(preds)
         prob_mean = preds_np.mean()
         prob_std = preds_np.std()

--- a/backend/tests/test_trial_predictor.py
+++ b/backend/tests/test_trial_predictor.py
@@ -23,7 +23,10 @@ def mock_trial_dict():
 
 @pytest.fixture
 def real_model_predictor(monkeypatch):
-    model_path = "../backend/app/models/model_weights.pth"
+    # Load model weights relative to this tests directory
+    model_path = os.path.join(
+        os.path.dirname(__file__), "..", "app", "models", "model_weights.pth"
+    )
     predictor = TrialPredictor(model_path=model_path, device="cpu")
 
     # Patch embeddings to fixed vectors matching expected dimensions


### PR DESCRIPTION
## Summary
- fix incorrect relative path to model in predictor tests
- ensure MC dropout is disabled after sampling

## Testing
- `pytest tests/test_trial_predictor.py::test_real_model_predict --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687fbbcc714c833080d3965b453e6ce0